### PR TITLE
Replacing GitHub Jobs with DevITjobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,8 @@ A collection of super-popular Interview questions, along with explanations and i
 ## List of sites where you can hunt for a developer job
 
 - :link: AngelList - https://angel.co
-- :link: GitHub: http://jobs.github.com
+- :link: DevITjobs.us: https://devitjobs.us
+- :link: DevITjobs.uk: https://devitjobs.uk
 - :link: Mashable: http://jobs.mashable.com/jobs
 - :link: Indeed: http://indeed.com
 - :link: StackOverflow: http://stackoverflow.com/jobs


### PR DESCRIPTION
GitHub jobs does not exist anymore: https://github.blog/changelog/2021-04-19-deprecation-notice-github-jobs-site

I suggest replacing it with DevITjobs - a job board with mandatory salary brackets & transparent tech stacks.