### PR TITLE
Update Collection-of-CSS-Questions.md

### DIFF
--- a/CSS/Collection-of-CSS-Questions.md
+++ b/CSS/Collection-of-CSS-Questions.md
@@ -363,9 +363,9 @@ For example with this selector `p span`, browsers firstly find all the `<span>` 
 
 ### Describe pseudo-elements and discuss what they are used for.
 
-A CSS pseudo-element is a keyword added to a selector that lets you style a specific part of the selected element(s). They can be used for decoration (`:first-line`, `:first-letter`) or adding elements to the markup (combined with `content: ...`) without having to modify the markup (`:before`, `:after`).
+A CSS pseudo-element is a keyword added to a selector that lets you style a specific part of the selected element(s). They can be used for decoration (`::first-line`, `::first-letter`) or adding elements to the markup (combined with `content: ...`) without having to modify the markup (`:before`, `:after`).
 
-- `:first-line` and `:first-letter` can be used to decorate text.
+- `::first-line` and `::first-letter` can be used to decorate text.
 - Used in the `.clearfix` hack as shown above to add a zero-space element with `clear: both`.
 - Triangular arrows in tooltips use `:before` and `:after`. Encourages separation of concerns because the triangle is considered part of styling and not really the DOM.
 


### PR DESCRIPTION
Notice the double colon notation - ::first-line versus :first-line

The double-colon replaced the single-colon notation for pseudo-elements in CSS3. This was an attempt from W3C to distinguish between pseudo-classes and pseudo-elements.

The single-colon syntax was used for both pseudo-classes and pseudo-elements in CSS2 and CSS1.

For backward compatibility, the single-colon syntax is acceptable for CSS2 and CSS1 pseudo-elements.